### PR TITLE
azure-pass-01

### DIFF
--- a/providers/src/azure/v00.00.00000/services/storage.yaml
+++ b/providers/src/azure/v00.00.00000/services/storage.yaml
@@ -1253,6 +1253,12 @@ components:
     ListContainerItem:
       description: The blob container properties be listed out.
       properties:
+        id:
+          type: string
+          description: Fully qualified resource ID for the Resource.
+        name:
+          type: string
+          description: The name of the resource
         properties:
           $ref: '#/components/schemas/ContainerProperties'
           x-ms-client-flatten: true
@@ -3235,6 +3241,13 @@ components:
     StorageAccount:
       description: The storage account.
       properties:
+        id:
+          readOnly: true
+          type: string
+          description: Resource Id
+        name:
+          type: string
+          description: Resource name
         sku:
           $ref: '#/components/schemas/Sku'
           readOnly: true
@@ -4845,6 +4858,12 @@ components:
     FileShareItem:
       description: The file share properties be listed out.
       properties:
+        name:
+          type: string
+          description: The name of the share.
+        id:
+          type: string
+          description: Fully qualified resource ID for the resource.
         properties:
           $ref: '#/components/schemas/FileShareProperties'
           x-ms-client-flatten: true
@@ -5330,14 +5349,14 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         set_service_properties:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1{tableServiceName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1{tableServiceName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5354,7 +5373,7 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1{tableServiceName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1{tableServiceName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5371,31 +5390,31 @@ components:
       methods:
         create:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}~1?api-version=2023-05-01/patch'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}?api-version=2023-05-01/patch'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1{tableName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1tableServices~1default~1tables?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5416,20 +5435,20 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1networkSecurityPerimeterConfigurations~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1networkSecurityPerimeterConfigurations?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1networkSecurityPerimeterConfigurations~1{networkSecurityPerimeterConfigurationName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1networkSecurityPerimeterConfigurations~1{networkSecurityPerimeterConfigurationName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         reconcile:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1networkSecurityPerimeterConfigurations~1{networkSecurityPerimeterConfigurationName}~1reconcile~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1networkSecurityPerimeterConfigurations~1{networkSecurityPerimeterConfigurationName}~1reconcile?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5447,14 +5466,14 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         set_service_properties:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1{BlobServicesName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1{BlobServicesName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5471,7 +5490,7 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1{BlobServicesName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1{BlobServicesName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5488,68 +5507,68 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         create:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1?api-version=2023-05-01/patch'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}?api-version=2023-05-01/patch'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         set_legal_hold:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1setLegalHold~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1setLegalHold?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         clear_legal_hold:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1clearLegalHold~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1clearLegalHold?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         lock_immutability_policy:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1default~1lock~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1default~1lock?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         extend_immutability_policy:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1default~1extend~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1default~1extend?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         lease:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1lease~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1lease?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         object_level_worm:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1migrate~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1migrate?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5569,19 +5588,19 @@ components:
       methods:
         create_or_update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1{immutabilityPolicyName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1{immutabilityPolicyName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1{immutabilityPolicyName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1{immutabilityPolicyName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1{immutabilityPolicyName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1blobServices~1default~1containers~1{containerName}~1immutabilityPolicies~1{immutabilityPolicyName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5600,14 +5619,14 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         set_service_properties:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1{queueServiceName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1{queueServiceName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5624,7 +5643,7 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1{queueServiceName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1{queueServiceName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5641,31 +5660,31 @@ components:
       methods:
         create:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}~1?api-version=2023-05-01/patch'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}?api-version=2023-05-01/patch'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1{queueName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1queueServices~1default~1queues?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5686,7 +5705,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1providers~1Microsoft.Storage~1operations~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1providers~1Microsoft.Storage~1operations?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5704,7 +5723,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1skus~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1skus?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5722,81 +5741,81 @@ components:
       methods:
         check_name_availability:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1checkNameAvailability~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1checkNameAvailability?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         create:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1?api-version=2023-05-01/patch'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}?api-version=2023-05-01/patch'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1storageAccounts~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1storageAccounts?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         list_by_resource_group:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         regenerate_key:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1regenerateKey~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1regenerateKey?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         failover:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1failover~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1failover?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         hierarchical_namespace_migration:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourcegroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1hnsonmigration~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourcegroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1hnsonmigration?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         abort_hierarchical_namespace_migration:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourcegroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1aborthnsonmigration~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourcegroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1aborthnsonmigration?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         customer_initiated_migration:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1startAccountMigration~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1startAccountMigration?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         restore_blob_ranges:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1restoreBlobRanges~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1restoreBlobRanges?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         revoke_user_delegation_keys:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1revokeUserDelegationKeys~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1revokeUserDelegationKeys?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5816,7 +5835,7 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5833,14 +5852,14 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1deletedAccounts~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1deletedAccounts?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1locations~1{location}~1deletedAccounts~1{deletedAccountName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1locations~1{location}~1deletedAccounts~1{deletedAccountName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5858,7 +5877,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1listKeys~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1listKeys?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5875,7 +5894,7 @@ components:
       methods:
         list_by_location:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1locations~1{location}~1usages~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1locations~1{location}~1usages?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5893,7 +5912,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1ListAccountSas~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1ListAccountSas?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5910,7 +5929,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1ListServiceSas~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1ListServiceSas?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5927,7 +5946,7 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1accountMigrations~1{migrationName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1accountMigrations~1{migrationName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5944,19 +5963,19 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1managementPolicies~1{managementPolicyName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1managementPolicies~1{managementPolicyName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         create_or_update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1managementPolicies~1{managementPolicyName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1managementPolicies~1{managementPolicyName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1managementPolicies~1{managementPolicyName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1managementPolicies~1{managementPolicyName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -5975,25 +5994,25 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies~1{blobInventoryPolicyName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies~1{blobInventoryPolicyName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         create_or_update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies~1{blobInventoryPolicyName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies~1{blobInventoryPolicyName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies~1{blobInventoryPolicyName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies~1{blobInventoryPolicyName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1inventoryPolicies?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6014,26 +6033,26 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections~1{privateEndpointConnectionName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         put:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections~1{privateEndpointConnectionName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateEndpointConnections~1{privateEndpointConnectionName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6052,7 +6071,7 @@ components:
       methods:
         list_by_storage_account:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateLinkResources~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1privateLinkResources?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6070,26 +6089,26 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies~1{objectReplicationPolicyId}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies~1{objectReplicationPolicyId}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         create_or_update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies~1{objectReplicationPolicyId}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies~1{objectReplicationPolicyId}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies~1{objectReplicationPolicyId}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1objectReplicationPolicies~1{objectReplicationPolicyId}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6109,32 +6128,32 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         create_or_update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         regenerate_password:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}~1regeneratePassword~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}~1regeneratePassword?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6154,7 +6173,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}~1listKeys~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1localUsers~1{username}~1listKeys?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6171,25 +6190,25 @@ components:
       methods:
         put:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes~1{encryptionScopeName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes~1{encryptionScopeName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         patch:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes~1{encryptionScopeName}~1?api-version=2023-05-01/patch'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes~1{encryptionScopeName}?api-version=2023-05-01/patch'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes~1{encryptionScopeName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes~1{encryptionScopeName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1encryptionScopes?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6208,14 +6227,14 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         set_service_properties:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1{FileServicesName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1{FileServicesName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6232,7 +6251,7 @@ components:
       methods:
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1{FileServicesName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1{FileServicesName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6249,44 +6268,44 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
             objectKey: $.value
         create:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1?api-version=2023-05-01/patch'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}?api-version=2023-05-01/patch'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         restore:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1restore~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1restore?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         lease:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1lease~1?api-version=2023-05-01/post'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1fileServices~1default~1shares~1{shareName}~1lease?api-version=2023-05-01/post'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6306,31 +6325,31 @@ components:
       methods:
         create:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}~1?api-version=2023-05-01/put'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}?api-version=2023-05-01/put'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         update:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}~1?api-version=2023-05-01/patch'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}?api-version=2023-05-01/patch'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         get:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         delete:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}~1?api-version=2023-05-01/delete'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}?api-version=2023-05-01/delete'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6351,7 +6370,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1reports~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1reports?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6369,7 +6388,7 @@ components:
       methods:
         list:
           operation:
-            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}~1reports~1?api-version=2023-05-01/get'
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Storage~1storageAccounts~1{accountName}~1storageTaskAssignments~1{storageTaskAssignmentName}~1reports?api-version=2023-05-01/get'
           response:
             mediaType: application/json
             openAPIDocKey: '200'
@@ -6381,7 +6400,7 @@ components:
         update: []
         delete: []
 paths:
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices?api-version=2023-05-01:
     get:
       tags:
         - TableServiceProperties
@@ -6404,7 +6423,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/{tableServiceName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/{tableServiceName}?api-version=2023-05-01:
     put:
       tags:
         - TableServiceProperties
@@ -6459,7 +6478,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/{tableName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/{tableName}?api-version=2023-05-01:
     put:
       tags:
         - TableService
@@ -6564,7 +6583,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables?api-version=2023-05-01:
     get:
       tags:
         - TableService
@@ -6589,7 +6608,7 @@ paths:
                 $ref: '#/components/schemas/CloudError'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations?api-version=2023-05-01:
     get:
       tags:
         - StorageAccounts NetworkSecurityPerimeterConfigurations
@@ -6614,7 +6633,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}?api-version=2023-05-01:
     get:
       tags:
         - StorageAccounts NetworkSecurityPerimeterConfigurations
@@ -6638,7 +6657,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts NetworkSecurityPerimeterConfigurations
@@ -6665,7 +6684,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices?api-version=2023-05-01:
     get:
       tags:
         - BlobService
@@ -6684,7 +6703,7 @@ paths:
                 $ref: '#/components/schemas/BlobServiceItems'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/{BlobServicesName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/{BlobServicesName}?api-version=2023-05-01:
     put:
       tags:
         - BlobService
@@ -6727,7 +6746,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlobServiceProperties'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers?api-version=2023-05-01:
     get:
       tags:
         - BlobContainers
@@ -6767,7 +6786,7 @@ paths:
                 $ref: '#/components/schemas/ListContainerItems'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}?api-version=2023-05-01:
     put:
       tags:
         - BlobContainers
@@ -6857,7 +6876,7 @@ paths:
           description: OK -- Delete Container operation completed successfully.
         '204':
           description: No Content -- The Container not exist.
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/setLegalHold/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/setLegalHold?api-version=2023-05-01:
     post:
       tags:
         - BlobContainers
@@ -6883,7 +6902,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LegalHold'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/clearLegalHold/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/clearLegalHold?api-version=2023-05-01:
     post:
       tags:
         - BlobContainers
@@ -6909,7 +6928,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LegalHold'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/{immutabilityPolicyName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/{immutabilityPolicyName}?api-version=2023-05-01:
     put:
       tags:
         - BlobContainers
@@ -7004,7 +7023,7 @@ paths:
               schema:
                 type: string
               description: The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers.
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default/lock/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default/lock?api-version=2023-05-01:
     post:
       tags:
         - BlobContainers
@@ -7033,7 +7052,7 @@ paths:
               schema:
                 type: string
               description: The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers.
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default/extend/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default/extend?api-version=2023-05-01:
     post:
       tags:
         - BlobContainers
@@ -7069,7 +7088,7 @@ paths:
               schema:
                 type: string
               description: The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers.
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/lease/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/lease?api-version=2023-05-01:
     post:
       tags:
         - BlobContainers
@@ -7094,7 +7113,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LeaseContainerResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/migrate/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/migrate?api-version=2023-05-01:
     post:
       tags:
         - BlobContainers
@@ -7119,7 +7138,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices?api-version=2023-05-01:
     get:
       tags:
         - QueueServiceProperties
@@ -7142,7 +7161,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/{queueServiceName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/{queueServiceName}?api-version=2023-05-01:
     put:
       tags:
         - QueueServiceProperties
@@ -7197,7 +7216,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}?api-version=2023-05-01:
     put:
       tags:
         - QueueService
@@ -7302,7 +7321,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues?api-version=2023-05-01:
     get:
       tags:
         - QueueService
@@ -7337,7 +7356,7 @@ paths:
                 $ref: '#/components/schemas/CloudError'
       x-ms-pageable:
         nextLinkName: nextLink
-  /providers/Microsoft.Storage/operations/?api-version=2023-05-01:
+  /providers/Microsoft.Storage/operations?api-version=2023-05-01:
     get:
       tags:
         - Operations
@@ -7353,7 +7372,7 @@ paths:
                 $ref: '#/components/schemas/OperationListResult'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/skus/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/skus?api-version=2023-05-01:
     get:
       tags:
         - Skus
@@ -7370,7 +7389,7 @@ paths:
                 $ref: '#/components/schemas/StorageSkuListResult'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7393,7 +7412,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckNameAvailabilityResult'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}?api-version=2023-05-01:
     put:
       tags:
         - StorageAccounts
@@ -7487,7 +7506,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StorageAccount'
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/deletedAccounts/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/deletedAccounts?api-version=2023-05-01:
     get:
       tags:
         - DeletedAccounts
@@ -7510,7 +7529,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/deletedAccounts/{deletedAccountName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/deletedAccounts/{deletedAccountName}?api-version=2023-05-01:
     get:
       tags:
         - DeletedAccounts
@@ -7538,7 +7557,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2023-05-01:
     get:
       tags:
         - StorageAccounts
@@ -7555,7 +7574,7 @@ paths:
                 $ref: '#/components/schemas/StorageAccountListResult'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts?api-version=2023-05-01:
     get:
       tags:
         - StorageAccounts
@@ -7573,7 +7592,7 @@ paths:
                 $ref: '#/components/schemas/StorageAccountListResult'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7600,7 +7619,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StorageAccountListKeysResult'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7625,7 +7644,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StorageAccountListKeysResult'
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/usages/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/usages?api-version=2023-05-01:
     get:
       tags:
         - LocationUsage
@@ -7648,7 +7667,7 @@ paths:
                 $ref: '#/components/schemas/UsageListResult'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/ListAccountSas/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/ListAccountSas?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7673,7 +7692,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListAccountSasResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/ListServiceSas/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/ListServiceSas?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7698,7 +7717,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListServiceSasResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/failover/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/failover?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7727,7 +7746,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/hnsonmigration/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/hnsonmigration?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7757,7 +7776,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/aborthnsonmigration/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/aborthnsonmigration?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7781,7 +7800,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/startAccountMigration/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/startAccountMigration?api-version=2023-05-01:
     post:
       tags:
         - AccountMigrations
@@ -7817,7 +7836,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/accountMigrations/{migrationName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/accountMigrations/{migrationName}?api-version=2023-05-01:
     get:
       tags:
         - AccountMigrations
@@ -7841,7 +7860,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/restoreBlobRanges/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/restoreBlobRanges?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -7875,7 +7894,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/{managementPolicyName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/{managementPolicyName}?api-version=2023-05-01:
     get:
       tags:
         - ManagementPolicies
@@ -7933,7 +7952,7 @@ paths:
           description: OK -- Delete the managementpolicy successfully.
         '204':
           description: No Content -- The managementpolicy does not exist.
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies/{blobInventoryPolicyName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies/{blobInventoryPolicyName}?api-version=2023-05-01:
     get:
       tags:
         - BlobInventoryPolicies
@@ -8009,7 +8028,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies?api-version=2023-05-01:
     get:
       tags:
         - BlobInventoryPolicies
@@ -8034,7 +8053,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateEndpointConnections/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateEndpointConnections?api-version=2023-05-01:
     get:
       tags:
         - PrivateEndpointConnections
@@ -8053,7 +8072,7 @@ paths:
                 $ref: '#/components/schemas/PrivateEndpointConnectionListResult'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}?api-version=2023-05-01:
     get:
       tags:
         - PrivateEndpointConnections
@@ -8129,7 +8148,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateLinkResources/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateLinkResources?api-version=2023-05-01:
     get:
       tags:
         - PrivateLinkResources
@@ -8146,7 +8165,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PrivateLinkResourceListResult'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/objectReplicationPolicies/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/objectReplicationPolicies?api-version=2023-05-01:
     get:
       tags:
         - ObjectReplicationPolicies
@@ -8171,7 +8190,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/objectReplicationPolicies/{objectReplicationPolicyId}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/objectReplicationPolicies/{objectReplicationPolicyId}?api-version=2023-05-01:
     get:
       tags:
         - ObjectReplicationPolicies
@@ -8247,7 +8266,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/revokeUserDelegationKeys/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/revokeUserDelegationKeys?api-version=2023-05-01:
     post:
       tags:
         - StorageAccounts
@@ -8267,7 +8286,7 @@ paths:
       responses:
         '200':
           description: OK -- revoke user delegation keys succeeded.
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers?api-version=2023-05-01:
     get:
       tags:
         - LocalUsers
@@ -8316,7 +8335,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-ms-pageable:
         nextLinkName: null
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}?api-version=2023-05-01:
     get:
       tags:
         - LocalUsers
@@ -8392,7 +8411,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}/listKeys/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}/listKeys?api-version=2023-05-01:
     post:
       tags:
         - LocalUsers
@@ -8416,7 +8435,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}/regeneratePassword/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}/regeneratePassword?api-version=2023-05-01:
     post:
       tags:
         - LocalUsers
@@ -8440,7 +8459,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/encryptionScopes/{encryptionScopeName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/encryptionScopes/{encryptionScopeName}?api-version=2023-05-01:
     put:
       tags:
         - EncryptionScopes
@@ -8532,7 +8551,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/encryptionScopes/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/encryptionScopes?api-version=2023-05-01:
     get:
       tags:
         - EncryptionScopes
@@ -8577,7 +8596,7 @@ paths:
                 $ref: '#/components/schemas/EncryptionScopeListResult'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices?api-version=2023-05-01:
     get:
       tags:
         - FileService
@@ -8600,7 +8619,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/{FileServicesName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/{FileServicesName}?api-version=2023-05-01:
     put:
       tags:
         - FileService
@@ -8655,7 +8674,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares?api-version=2023-05-01:
     get:
       tags:
         - FileShares
@@ -8696,7 +8715,7 @@ paths:
                 $ref: '#/components/schemas/CloudError'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}?api-version=2023-05-01:
     put:
       tags:
         - FileShares
@@ -8840,7 +8859,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}/restore/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}/restore?api-version=2023-05-01:
     post:
       tags:
         - FileShares
@@ -8867,7 +8886,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}/lease/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}/lease?api-version=2023-05-01:
     post:
       tags:
         - FileShares
@@ -8909,7 +8928,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CloudError'
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}?api-version=2023-05-01:
     put:
       tags:
         - StorageTaskAssignments
@@ -9047,7 +9066,7 @@ paths:
       x-ms-long-running-operation: true
       x-ms-long-running-operation-options:
         final-state-via: location
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments?api-version=2023-05-01:
     get:
       tags:
         - StorageTaskAssignments
@@ -9077,7 +9096,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/reports/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/reports?api-version=2023-05-01:
     get:
       tags:
         - StorageTaskAssignments
@@ -9112,7 +9131,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-ms-pageable:
         nextLinkName: nextLink
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}/reports/?api-version=2023-05-01:
+  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}/reports?api-version=2023-05-01:
     get:
       tags:
         - StorageTaskAssignments


### PR DESCRIPTION
## Summary

- A bunch of `azure.storage` schema objects are lacking `name` and `id` attributes in schema definition that are actually present in response bodies, and significant.  Eg: `FileShareItem`.
- Trailing `/` immediately followed by query parameters is sometimes ok, sometimes not; either way appears erroneous.